### PR TITLE
Missing licence field

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,8 @@
   "version": "1.0.0",
   "author": "",
   "description": "",
+  "license": "UNLICENSED",
+  "private": true,
   "main": "index.js",
   "engines": {
     "node": ">=0.14.x"


### PR DESCRIPTION
### Add the missing license in `package.json`.

Due your repo is a personal website project, using `UNLICENSED` is just fine.
For more open-source licenses, you may refer [五種開源授權規範的比較 (BSD, Apache, GPL, LGPL, MIT)](http://inspiregate.com/internet/trends/74-comparison-of-five-kinds-of-standard-open-source-license-bsd-apache-gpl-lgpl-mit.html).


**PS:**
But if you wanna change to open-source license,
please remember create a `LICENSE` file in the root. 😉